### PR TITLE
make is_done functional

### DIFF
--- a/nidaqmx/libnidaqmx.py
+++ b/nidaqmx/libnidaqmx.py
@@ -837,8 +837,8 @@ class Task(uInt32):
         operation is complete before you stop the task.
         """
         b = bool32(0)
-        if not CALL('IsTaskDone', self, ctypes.byref(b)):
-            return b != 0
+        CALL('IsTaskDone', self, ctypes.byref(b))
+        return b.value != 0
 
     # NotImplemented: DAQmxGetTaskComplete
 


### PR DESCRIPTION
previously is done did only call the return part if an error occurred
and then always returned True because it compares a ctypes class
against an int, which will never be equal.