### PR TITLE
TaskHandle is a void* and should be used instead of uInt32

### DIFF
--- a/nidaqmx/libnidaqmx.py
+++ b/nidaqmx/libnidaqmx.py
@@ -40,13 +40,13 @@ uInt8 = ctypes.c_uint8
 int16 = ctypes.c_int16
 uInt16 = ctypes.c_uint16
 int32 = ctypes.c_int32
-TaskHandle = bool32 = uInt32 = ctypes.c_uint32
+bool32 = uInt32 = ctypes.c_uint32
 int64 = ctypes.c_int64
 uInt64 = ctypes.c_uint64
 
 float32 = ctypes.c_float
 float64 = ctypes.c_double
-void_p = ctypes.c_void_p
+TaskHandle = void_p = ctypes.c_void_p
 
 # Increase default_buf_size value when receiving RuntimeError
 # with "Buffer is too small to fit the string." message.

--- a/nidaqmx/libnidaqmx.py
+++ b/nidaqmx/libnidaqmx.py
@@ -721,7 +721,7 @@ class System(object):
         names = [n.strip() for n in buf.value.split(',') if n.strip()]
         return names
 
-class Task(uInt32):
+class Task(TaskHandle):
 
     """
     Base class to NI-DAQmx task classes.


### PR DESCRIPTION
at least in NIDAQmx 15.1 TaskHandle is defined as a void* and not as a
uInt32. In practice this makes no difference on 32 bit system (or 64bit
systems running 32bit Python), however with 64bit bit it does.

This change additonally let's Task inherit from TaskHandle instead of uInt32 (which are the same for 32 bit systems)

This is tested on a Windows 7 64-bit using 64bit WinPythin. The system is
running a set of 6353 cards currently using CounterOutputs and
AnalogOutputs. This is not tested on 32 bit python, but it shouldn't have
any changes on these systems.