### PR TITLE
ctypes LoadLibrary can't handle unicode strings

### DIFF
--- a/nidaqmx/libnidaqmx.py
+++ b/nidaqmx/libnidaqmx.py
@@ -101,7 +101,7 @@ def _find_library_nt():
         else:
             libfile = None
 
-    return header_name, libname, libfile
+    return header_name, libname, str(libfile)
 
 def _find_library():
     if os.name == "nt":


### PR DESCRIPTION
This fixes an exception I was receiving while trying to import nidaqmx

`>>> import nidaqmx
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\packet\Anaconda2\lib\site-packages\nidaqmx\__init__.py", line 83, in <module>
    from .libnidaqmx import AnalogInputTask, AnalogOutputTask,\
  File "C:\Users\packet\Anaconda2\lib\site-packages\nidaqmx\libnidaqmx.py", line 128, in <module>
    _header_name, libnidaqmx = _find_library()
  File "C:\Users\packet\Anaconda2\lib\site-packages\nidaqmx\libnidaqmx.py", line 121, in _find_library
    lib = ctypes.windll.LoadLibrary(libfile)
  File "C:\Users\packet\Anaconda2\lib\ctypes\__init__.py", line 440, in LoadLibrary
    return self._dlltype(name)
  File "C:\Users\packet\Anaconda2\lib\ctypes\__init__.py", line 362, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: LoadLibrary() argument 1 must be string, not unicode`