### PR TITLE
fix callback functions deregistering tasks

### DIFF
--- a/nidaqmx/libnidaqmx.py
+++ b/nidaqmx/libnidaqmx.py
@@ -101,7 +101,7 @@ def _find_library_nt():
         else:
             libfile = None
 
-    return header_name, libname, libfile
+    return header_name, libname, str(libfile)
 
 def _find_library():
     if os.name == "nt":


### PR DESCRIPTION
previously callbacks created a new Python instance of the corresponding
task. This caused two (or more) Python classes for the same nidaq task
to exist. As soon as one of them went out of scope the cleanup code was
called and the task was cleared, causing all later calls using the
existing instance to fail.

This fixes the issue by maintaining a cache off all registered tasks. A
small wrapper function is generated. This function picks the correct Task
instance based on the task id of the task generating the callback.

This solves the problems described in #7. I tested `every_n_samples_event`s and `done_event`s.